### PR TITLE
Upgrade to latest KM nugets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.11.0" />
-    <PackageVersion Include="Microsoft.KernelMemory.Abstractions" Version="0.24.231228.5" />
-    <PackageVersion Include="Microsoft.KernelMemory.Core" Version="0.24.231228.5" />
+    <PackageVersion Include="Microsoft.KernelMemory.Abstractions" Version="0.25.240103.1" />
+    <PackageVersion Include="Microsoft.KernelMemory.Core" Version="0.25.240103.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>
   <!-- Sources -->


### PR DESCRIPTION
This PR simply brings ES up to KM 0.25, the latest build. The upgrade shouldn't have any impact.

Notes:
* KM service now completely works with nugets rather than direct links to source code (see https://github.com/microsoft/kernel-memory/blob/main/service/Service/Service.csproj#L30-L37). In particular the service works with a specific version of the Abstractions package, that is also used here for the ElasticSearch adapter.
* `KernelMemoryBuilder.FromAppSettings` is now part of the Service project (see https://github.com/microsoft/kernel-memory/blob/main/service/Service/KernelMemoryBuilderExtensions.cs) so we can add the ElasticSearch dependency to the Service project, without touching Core, and make it very easy to use ES without dealing with nuget install. I'm planning to do this as soon as ES nuget is up to date, and I guess it will take some maintenance to keep the package aligned. I'm looking at options to reduce the effort, e.g. freezing the Abstractions nuget versioning. Worse case scenario, we might drop ES from Service source code, providing manual steps instead (TBD).
